### PR TITLE
Optimized the Map Sync between client and server

### DIFF
--- a/ServerSideMap/ExplorationDatabase.cs
+++ b/ServerSideMap/ExplorationDatabase.cs
@@ -119,9 +119,6 @@ namespace ServerSideMap
             var m =  Traverse.Create(typeof(Minimap)).Field("m_instance").GetValue() as Minimap;
             var flag = _Minimap.Explore(m, x, y);
             _dirty = flag || _dirty;
-            
-            var l = BepInEx.Logging.Logger.CreateLogSource("ServerSideMap");
-            l.LogInfo("Received relayed explore from server");
         }
         
 

--- a/ServerSideMap/InitialMapSync.cs
+++ b/ServerSideMap/InitialMapSync.cs
@@ -1,10 +1,50 @@
-using System;
 using HarmonyLib;
+using UnityEngine;
+using Logger = BepInEx.Logging.Logger;
 
 namespace ServerSideMap
 {
     public class InitialMapSync
     {
+        public static void OnReceiveMapDataInitial(ZRpc client, ZPackage mapData)
+        {
+            var l = BepInEx.Logging.Logger.CreateLogSource("ServerSideMap");
+            l.LogInfo("Client received initial map data by server");
+
+            var explored = ExplorationDatabase.UnpackBoolArray(mapData);
+
+            for (var index = 0; index < explored.Length; index++)
+            {
+                if (explored[index])
+                {
+                    _Minimap.Explore(_Minimap._instance, index % ExplorationDatabase.MapSize, index / ExplorationDatabase.MapSize);
+                }
+            }
+            
+            var fogTexture =  Traverse.Create((_Minimap._instance)).Field("m_fogTexture").GetValue() as Texture2D;
+            fogTexture.Apply();
+            
+            explored = Traverse.Create(_Minimap._instance).Field("m_explored").GetValue() as bool[];
+            var z = ExplorationDatabase.PackBoolArray(explored);
+            if (_ZNet.IsServer(_ZNet._instance))
+            {
+                OnClientInitialData(null, z);
+            }
+            else
+            {
+                var znet =  Traverse.Create(typeof(ZNet)).Field("m_instance").GetValue() as ZNet;
+                ZRpc server = _ZNet.GetServerRPC(znet);
+                server.Invoke("OnClientInitialData", (object) z);
+            }
+        }
+        
+        public static void OnClientInitialData(ZRpc client,  ZPackage mapData)
+        {
+            var l = Logger.CreateLogSource("ServerSideMap");
+            l.LogInfo("Server received initial map data by client");
+            ExplorationDatabase.MergeExplorationArray(ExplorationDatabase.UnpackBoolArray(mapData));
+        }
+        
         // ReSharper disable once InconsistentNaming
         [HarmonyPatch(typeof (ZNet), "RPC_PeerInfo")]
         private  class ZnetPatchRPC_PeerInfo
@@ -14,17 +54,35 @@ namespace ServerSideMap
             {
                 if (__instance.IsServer())
                 {
-                    for (var i = 0; i < ExplorationDatabase.MapSize*ExplorationDatabase.MapSize; i++)
-                    {
-                        if (ExplorationDatabase.GetExplored(i))
-                        {
-                            var z = new ZPackage();
-                            z.Write(i % ExplorationDatabase.MapSize );
-                            z.Write(i / ExplorationDatabase.MapSize);
-                            rpc.Invoke("OnReceiveMapData", (object) z);
-                        }
-                    }
+                    var z = ExplorationDatabase.PackBoolArray(ExplorationDatabase.GetExplorationArray());
+                    rpc.Invoke("OnReceiveMapDataInitial", (object) z);
                 }
+                else
+                {
+                    var l = Logger.CreateLogSource("ServerSideMap");
+                }
+            }
+        }
+        
+                
+        [HarmonyPatch(typeof (Minimap), "SetMapData", typeof(byte[]))]
+        private class MinimapPatchSetMapData
+        {
+            // ReSharper disable once InconsistentNaming
+            private static void Postfix(Minimap __instance)
+            {
+                // var explored = Traverse.Create(__instance).Field("m_explored").GetValue() as bool[];
+                // var z = ExplorationDatabase.PackBoolArray(explored);
+                // if (_ZNet.IsServer(_ZNet._instance))
+                // {
+                //     OnClientInitialData(null, z);
+                // }
+                // else
+                // {
+                //     var znet =  Traverse.Create(typeof(ZNet)).Field("m_instance").GetValue() as ZNet;
+                //     ZRpc server = _ZNet.GetServerRPC(znet);
+                //     // server.Invoke("OnClientInitialData", (object) z);
+                // }
             }
         }
     }

--- a/ServerSideMap/ServerSideMap.cs
+++ b/ServerSideMap/ServerSideMap.cs
@@ -7,7 +7,7 @@ using HarmonyLib;
 
 namespace ServerSideMap
 {
-    [BepInPlugin("eu.mydayyy.plugins.serversidemap", "ServerSideMap", "1.0.0.0")]
+    [BepInPlugin("eu.mydayyy.plugins.serversidemap", "ServerSideMap", "1.1.0.0")]
     public class ServerSideMap : BaseUnityPlugin
     {
         void Awake()

--- a/ServerSideMap/ServerSideMap.cs
+++ b/ServerSideMap/ServerSideMap.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using BepInEx;
 using HarmonyLib;
@@ -13,6 +14,26 @@ namespace ServerSideMap
         {
             var harmony = new Harmony("eu.mydayyy.plugins.serversidemap");
             Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), (string) null);
+            
+            
+            // Random rnd = new Random();
+            // var l = BepInEx.Logging.Logger.CreateLogSource("SSM");
+            //
+            // var size = 2048*2048;
+            //
+            // for (var k = 0; k < 10000; k++)
+            // {
+            //     var arr = new bool[size];
+            //     for (var i = 0; i < size; i++)
+            //     {
+            //         arr[i] = rnd.NextDouble() > 0.5;
+            //     }
+            //
+            //     var decompressed = ExplorationDatabase.UnpackBoolArray(ExplorationDatabase.PackBoolArray(arr));
+            //     bool isEqual = Enumerable.SequenceEqual(arr, decompressed);
+            //     l.LogInfo("equal: " + isEqual);
+            // }
+
         }
 
         [HarmonyPatch(typeof (ZNet), "OnNewConnection")]
@@ -24,10 +45,12 @@ namespace ServerSideMap
                 if (__instance.IsServer())
                 {
                     peer.m_rpc.Register<int, int>("OnClientExplore", new Action<ZRpc, int, int>(ExplorationMapSync.OnClientExplore));
+                    peer.m_rpc.Register<ZPackage>("OnClientInitialData", new Action<ZRpc, ZPackage>(InitialMapSync.OnClientInitialData));
                 }
                 else
                 {
                     peer.m_rpc.Register<ZPackage>("OnReceiveMapData", new Action<ZRpc, ZPackage>(ExplorationDatabase.OnReceiveMapData));
+                    peer.m_rpc.Register<ZPackage>("OnReceiveMapDataInitial", new Action<ZRpc, ZPackage>(InitialMapSync.OnReceiveMapDataInitial));
                 }
             }
         }

--- a/ServerSideMap/_Minimap.cs
+++ b/ServerSideMap/_Minimap.cs
@@ -7,6 +7,17 @@ namespace ServerSideMap
     // ReSharper disable once InconsistentNaming
     public class _Minimap
     {
+        public static Minimap _instance;
+        
+        [HarmonyPatch(typeof(Minimap), "Awake")]
+        public static class Awake
+        {
+            private static void Postfix(Minimap __instance)
+            {
+                _instance = __instance;
+            }
+        }
+        
             [HarmonyReversePatch]
             [HarmonyPatch(typeof(Minimap), "Explore", typeof(int), typeof(int))]
             public static bool Explore(Minimap instance, int x, int y)


### PR DESCRIPTION
Following changes were made:

- The MapSync while actively exploring and the initial map sync between client and server are now fully separate processes
- During active exploration, the client uses RPC to let the server know about newly explored locations, which the server then relays to all other clients
- During initial map sync, the client transfers the entire exploration data in one RPC call instead of many calls. In addition the huge 2048*2048 boolean array the game uses will be compressed by 87.5% for transferring over the wire
